### PR TITLE
PowerShell script improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # Script that configures a Relying Party in ADFS
-==========
 
 ADFS Auth0 script
+
+## Usage
+
+Download the script to a local folder.
+Open PowerShell and navigate to that folder.
+Execute: `.\adfs.ps1` to load the functions.
+
+## Functions
+
+- `Add-RelyingPartner` (legacy alias: `AddRelyingPartner`)
+- `Remove-RelyingPartner` (legacy alias: `RemoveRelyingPartner`)
 
 ## Issue Reporting
 

--- a/adfs.ps1
+++ b/adfs.ps1
@@ -3,25 +3,39 @@
 # Descrption: Add and remove a relying party to ADFS with rules
 ######################################################################
 
-function AddRelyingParty
-(
-[string]$realm = $(throw "Realm for the application is required. E.g.: http://whatever.com or urn:whatever"),
-[string]$webAppEndpoint = $(throw "Endpoint where the token will be POSTed is required")
-)
-{
+function Add-RelyingParty {
+  <#
+  .SYNOPSIS
+    Add a relying party to ADFS with rules.
+  .PARAMETER realm
+    Required: The realm for the application. E.g http://whatever.com or urn:whatever.
+  .PARAMETER webAppEndpoint
+    Required: The endpoint where the token will be POSTed.
+  #>
+  [alias('AddRelyingParty')]
+  [CmdletBinding(SupportsShouldProcess)]
+  param(
+    [Parameter(Mandatory)]
+    [string]
+    $realm,
+    
+    [Parameter(Mandatory)]
+    [string]
+    $webAppEndpoint
+  )
+
   # In ADFS 3.0, management Cmdlets are moved into 'ADFS' module which gets auto-laoded. No more explicit snapin loading required.
   # [Fix]: Only attempt snapin loading if ADFS commands are not available
-  if ( (Get-Command Set-ADFSRelyingPartyTrust -ErrorAction SilentlyContinue) -eq $null)
+  if ( $null -eq (Get-Command Set-ADFSRelyingPartyTrust -ErrorAction SilentlyContinue))
   {
     # check if SP snapin exists in the machine
-    if ( (Get-PSSnapin -Name Microsoft.Adfs.Powershell -Registered -ErrorAction SilentlyContinue) -eq $null )
+    if ($null -eq (Get-PSSnapin -Name Microsoft.Adfs.Powershell -Registered -ErrorAction SilentlyContinue))
     {
-        Write-Error "This PowerShell script requires the Microsoft.Adfs.Powershell Snap-In. Try executing it from an ADFS server"
-        return;
+        Throw "This PowerShell script requires the Microsoft.Adfs.Powershell Snap-In. Try executing it from an ADFS server"
     }
 
     # check if SP snapin is already loaded, if not load it
-    if ( (Get-PSSnapin -Name Microsoft.Adfs.Powershell -ErrorAction SilentlyContinue) -eq $null )
+    if ($null -eq (Get-PSSnapin -Name Microsoft.Adfs.Powershell -ErrorAction SilentlyContinue))
     {
         Write-Verbose "Adding Microsoft.Adfs.Powershell Snapin"
         Add-PSSnapin Microsoft.Adfs.Powershell
@@ -31,70 +45,79 @@ function AddRelyingParty
     $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
     if ($currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator) -eq $false) 
     {
-      Write-Error "This PowerShell script requires Administrator privilieges. Try executing by doing right click -> 'Run as Administrator'"
-      return;
+      Throw "This PowerShell script requires Administrator privilieges. Try executing by doing right click -> 'Run as Administrator'"
     }
   }
   
-  # remove if exists
-  $rp = Get-ADFSRelyingPartyTrust -Name $realm
-  if ($rp) 
+  if ($PSCmdlet.ShouldProcess($realm))
   {
-    Write-Verbose "Removing Relying Party Trust: $realm"
-    Remove-ADFSRelyingPartyTrust -TargetName $realm
-  }
+    # remove if exists
+    $rp = Get-ADFSRelyingPartyTrust -Name $realm
+    if ($rp) 
+    {
+      Write-Verbose "Removing Relying Party Trust: $realm"
+      Remove-ADFSRelyingPartyTrust -TargetName $realm
+    }
 
-  Write-Verbose "Adding Relying Party Trust: $realm"
-  Write-Verbose "Add-ADFSRelyingPartyTrust -Name $realm -Identifier $realm -WSFedEndpoint $webAppEndpoint"
-  Add-ADFSRelyingPartyTrust -Name $realm -Identifier $realm -WSFedEndpoint $webAppEndpoint
+    Write-Verbose "Adding Relying Party Trust: $realm"
+    Write-Verbose "Add-ADFSRelyingPartyTrust -Name $realm -Identifier $realm -WSFedEndpoint $webAppEndpoint"
+    Add-ADFSRelyingPartyTrust -Name $realm -Identifier $realm -WSFedEndpoint $webAppEndpoint
 
-  # get the RP to add Transform and Authz rules.
-  $rp = Get-ADFSRelyingPartyTrust -Name $realm
+    # get the RP to add Transform and Authz rules.
+    $rp = Get-ADFSRelyingPartyTrust -Name $realm
 
-  # transform Rules
-  $rules = @'
-  @RuleName = "Store: ActiveDirectory -> Mail (ldap attribute: mail), Name (ldap attribute: userPrincipalName), GivenName (ldap attribute: givenName), Surname (ldap attribute: sn)" 
-  c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname", Issuer == "AD AUTHORITY"]
-   => issue(store = "Active Directory", types = ("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", 
-   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", 
-   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", 
-   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", 
-   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"), query = ";mail,displayName,userPrincipalName,givenName,sn;{0}", param = c.Value);
+    # transform Rules
+    $rules = @'
+@RuleName = "Store: ActiveDirectory -> Mail (ldap attribute: mail), Name (ldap attribute: userPrincipalName), GivenName (ldap attribute: givenName), Surname (ldap attribute: sn)" 
+c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname", Issuer == "AD AUTHORITY"]
+  => issue(store = "Active Directory", types = ("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", 
+  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", 
+  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", 
+  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", 
+  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"), query = ";mail,displayName,userPrincipalName,givenName,sn;{0}", param = c.Value);
 '@
-  
-  Write-Verbose "Adding Claim Rules"
-  Set-ADFSRelyingPartyTrust –TargetName $realm -IssuanceTransformRules $rules
+    
+    Write-Verbose "Adding Claim Rules"
+    Set-ADFSRelyingPartyTrust –TargetName $realm -IssuanceTransformRules $rules
 
-  # Authorization Rules
-  $authRules = '=> issue(Type = "http://schemas.microsoft.com/authorization/claims/permit", Value = "true");'
-  Write-Verbose "Adding Issuance Authorization Rules: $authRules"
-  $rSet = New-ADFSClaimRuleSet –ClaimRule $authRules
-  Set-ADFSRelyingPartyTrust –TargetName $realm –IssuanceAuthorizationRules $rSet.ClaimRulesString
+    # Authorization Rules
+    $authRules = '=> issue(Type = "http://schemas.microsoft.com/authorization/claims/permit", Value = "true");'
+    Write-Verbose "Adding Issuance Authorization Rules: $authRules"
+    $rSet = New-ADFSClaimRuleSet –ClaimRule $authRules
+    Set-ADFSRelyingPartyTrust –TargetName $realm –IssuanceAuthorizationRules $rSet.ClaimRulesString
 
+    Write-Host "Relying Party Trust '$realm' added succesfully."
+  }
   Remove-PSSnapin Microsoft.Adfs.Powershell -ErrorAction SilentlyContinue
-
-  Write-Host "Relying Party Trust '$realm' added succesfully."
-
 }
 
 
-function RemoveRelyingParty
-(
-[string]$realm = $(throw "Realm for the application is required. E.g.: http://whatever.com or urn:whatever")
-)
-{
+function Remove-RelyingParty {
+  <#
+  .SYNOPSIS
+    Removes a relying party from ADFS.
+  .PARAMETER realm
+    Required: The realm for the application. E.g http://whatever.com or urn:whatever.
+  #>
+  [alias('RemoveRelyingParty')]
+  [CmdletBinding(SupportsShouldProcess)]
+  param(
+    [Parameter(Mandatory)]
+    [string]
+    $realm
+  )
 
-  if ( (Get-Command Set-ADFSRelyingPartyTrust -ErrorAction SilentlyContinue) -eq $null)
+
+  if ($null -eq (Get-Command Set-ADFSRelyingPartyTrust -ErrorAction SilentlyContinue))
   {
     # check if ADFS snapin exists in the machine
-    if ( (Get-PSSnapin -Name Microsoft.Adfs.Powershell -Registered -ErrorAction SilentlyContinue) -eq $null )
+    if ($null -eq (Get-PSSnapin -Name Microsoft.Adfs.Powershell -Registered -ErrorAction SilentlyContinue))
     {
-        Write-Error "This PowerShell script requires the Microsoft.Adfs.Powershell Snap-In. Try executing it from an ADFS server"
-        return;
+        Throw "This PowerShell script requires the Microsoft.Adfs.Powershell Snap-In. Try executing it from an ADFS server"
     }
 
     # check if ADFSP snapin is already loaded, if not load it
-    if ( (Get-PSSnapin -Name Microsoft.Adfs.Powershell -ErrorAction SilentlyContinue) -eq $null )
+    if ($null -eq (Get-PSSnapin -Name Microsoft.Adfs.Powershell -ErrorAction SilentlyContinue))
     {
         Write-Verbose "Adding Microsoft.Adfs.Powershell Snapin"
         Add-PSSnapin Microsoft.Adfs.Powershell
@@ -104,20 +127,20 @@ function RemoveRelyingParty
     $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
     if ($currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator) -eq $false) 
     {
-        Write-Error "This PowerShell script requires Administrator privilieges. Try executing by doing right click -> 'Run as Administrator'"
-        return;
+        Throw "This PowerShell script requires Administrator privilieges. Try executing by doing right click -> 'Run as Administrator'"
     }
   }
-
-  # remove if exists
-  $rp = Get-ADFSRelyingPartyTrust -Name $realm
-  if ($rp) 
-  {
-    Write-Verbose "Removing Relying Party Trust: $realm"
-    Remove-ADFSRelyingPartyTrust -TargetName $realm
-    Write-Host "Relying Party Trust '$realm' removed succesfully."
+  
+  if ($PSCmdlet.ShouldProcess($realm))
+  {   
+    # remove if exists
+    $rp = Get-ADFSRelyingPartyTrust -Name $realm
+    if ($rp) 
+    {
+      Write-Verbose "Removing Relying Party Trust: $realm"
+      Remove-ADFSRelyingPartyTrust -TargetName $realm
+      Write-Host "Relying Party Trust '$realm' removed succesfully."
+    }
   }
-
   Remove-PSSnapin Microsoft.Adfs.Powershell -ErrorAction SilentlyContinue
-
 }


### PR DESCRIPTION
This PR makes the following improvements to this PowerShell script:

- Renames the functions to have PowerShell approved verb-noun names. Uses `alias` to ensure the previous function names still work for backwards compatibility.
- Adds comment based help to the functions so `get-help` will return useful output.
- Adds `cmdletbinding` and `supportsshouldprocess` so default parameters such as `-whatif` and `-verbose` can be used.
- Makes the parameters mandatory rather than using `throw` if no input is provided.
- Puts `$null` on the left side of comparisons to avoid potential false positives.
- Changes sections using `write-error` and `return` into the simpler `throw` which achieves the same result.

Note that these changes should still allow these functions to be used in exactly the same way as they were previously (no breaking changes), these changes just add the additional safety of the `-whatif` switch being available and other PowerShell best practice improvements.